### PR TITLE
Punctuation fix in import message

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -359,7 +359,7 @@ async function workspaceContainsBuildFiles(): Promise<boolean> {
 }
 
 async function promptUserForStandardServer(config: WorkspaceConfiguration): Promise<boolean> {
-	const choice: string = await window.showInformationMessage("The workspace contains Java projects, would you like to import them?", "Yes", "Always", "Later");
+	const choice: string = await window.showInformationMessage("The workspace contains Java projects; would you like to import them?", "Yes", "Always", "Later");
 	switch (choice) {
 		case "Always":
 			await config.update("project.importOnFirstTimeStartup", "automatic", ConfigurationTarget.Global);


### PR DESCRIPTION
Minor punctuation fix: these are two independent clauses, and thus joining them with a comma is incorrect in formal written English.

    The workspace contains Java projects, would you like to import them?
                                        ↑

An alternative to the one in this PR would be two separate sentences:

    The workspace contains Java projects. Would you like to import them?

…but I proposed the semicolon because it’s Java!